### PR TITLE
Flutterの残骸を削除 - .gitignoreから関連記述を削除

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,22 +1,3 @@
-# Flutter
-**/doc/api/
-**/ios/Flutter/.last_build_id
-.dart_tool/
-.flutter-plugins
-.flutter-plugins-dependencies
-.packages
-.pub-cache/
-.pub/
-/build/
-web/build/
-
-# If you're building an application, you may want to check-in your pubspec.lock
-pubspec.lock
-
-# Directory created by dartdoc
-# If you don't generate documentation locally you can remove this line.
-doc/api/
-
 # dotenv environment variables file
 .env*
 


### PR DESCRIPTION
## Flutter残骸の削除

このPRでは、廃止されたFlutterプロジェクトの残骸を削除します。

### 既に完了した作業
- ✅ `.gitignore`ファイルからFlutter関連の記述を削除

### 手動削除が必要な残骸
- ❌ `web/`ディレクトリ全体（Flutter webプロジェクトの残骸）
  - `web/pubspec.yaml` - Flutterプロジェクト設定
  - `web/lib/` - Dartソースコード
  - `web/build/` - Flutterビルド成果物
  - `web/web/` - Web関連アセット

### 次の手順
`web/`ディレクトリは、GitHub Web UIで以下の手順で削除してください：

1. このPRをマージ
2. GitHub Web UIで`web/`ディレクトリを開く
3. ディレクトリ全体を削除
4. 「Delete web directory」などのコミットメッセージでコミット

これでFlutterの残骸が完全に削除され、よりシンプルな構成になります。